### PR TITLE
Fix Twitch embeds by adding parent query param

### DIFF
--- a/JavaScript/categories.js
+++ b/JavaScript/categories.js
@@ -108,7 +108,7 @@ async function injectCategoryData () {
       var iframe = document.createElement("iframe");
       iframe.width = "352";
       iframe.height = "198";
-      iframe.src = category["videos"][i].video;
+      iframe.src = category["videos"][i].video + "&parent=banjospeedruns.com";
       iframe.frameborder = "0";
       iframe.allowfullscreen = "true";
       videoP.appendChild(iframe);

--- a/JavaScript/categories.js
+++ b/JavaScript/categories.js
@@ -108,7 +108,7 @@ async function injectCategoryData () {
       var iframe = document.createElement("iframe");
       iframe.width = "352";
       iframe.height = "198";
-      iframe.src = category["videos"][i].video + "&parent=banjospeedruns.com";
+      iframe.src = category["videos"][i].video;
       iframe.frameborder = "0";
       iframe.allowfullscreen = "true";
       videoP.appendChild(iframe);

--- a/btlevels/ck.json
+++ b/btlevels/ck.json
@@ -24,7 +24,7 @@
 		{
 			"name": "Hag 1 Egg Route (100%)",
 			"description": "Optimal egg routing during Hag 1 for the 100% category.",
-			"video": "https://player.twitch.tv/?video=v292142093&autoplay=false"
+			"video": "https://player.twitch.tv/?video=v292142093&autoplay=false&parent=banjospeedruns.com"
 		}
 	],
 	"cwkshots": [],
@@ -32,7 +32,7 @@
 	"outofbounds": [{
 			"name": "Cauldron Keep Early",
 			"description": "Using a wall and the pipe leading up to the Cauldron Keep entrance, you can beak bust when Banjo makes contact with the wall to clip through it. You can then climb up the rest of the pipe from out-of-bounds and flutter behind the lasers guarding the door to enter the level early.",
-			"video": "https://player.twitch.tv/?video=v125481941&autoplay=false"
+			"video": "https://player.twitch.tv/?video=v125481941&autoplay=false&parent=banjospeedruns.com"
 		},
 		{
 				"name": "70 Jiggy Barrier Skip",

--- a/btlevels/tdl.json
+++ b/btlevels/tdl.json
@@ -71,7 +71,7 @@
 	"cwkwarps": [{
 			"name": "TDL Early",
 			"description": "In Unga Bungas' Cave, Banjo takes damage from an enemy at the same time a clockwork enters the loading zone to TDL, warping Banjo to the other side of the loading zone.",
-			"video": "https://player.twitch.tv/embed?video=v492599455&autoplay=false"
+			"video": "https://player.twitch.tv/embed?video=v492599455&autoplay=false&parent=banjospeedruns.com"
 		},
 		{
 			"name": "Chompasaurus Warp",

--- a/btlevels/ww.json
+++ b/btlevels/ww.json
@@ -40,7 +40,7 @@
 	"cwkshots": [{
 			"name": "DCW Clockwork Shot from GGM Side",
 			"description": "A clockwork egg can clip through the Saucer of Peril door from the GGM side to activate the button and set up DCW.",
-			"video": "https://player.twitch.tv/embed?video=v41042514&autoplay=false"
+			"video": "https://player.twitch.tv/embed?video=v41042514&autoplay=false&parent=banjospeedruns.com"
 		}
 	],
 	"cwkwarps": [],


### PR DESCRIPTION
According to [Twitch's Documentation](https://dev.twitch.tv/docs/embed/video-and-clips/#non-interactive-inline-frames-for-live-streams-and-vods) this should be all we need to do in order to have Twitch embeds working

I can't test this fully in a local environment but when I made this change the player error changed from `Whoops! This embed is misconfigured.` to `Blocked by Content Security Policy`